### PR TITLE
Removing Excess curly brace in the "Index.cshtml" 

### DIFF
--- a/MvcAdminTemplate/Views/Forms/Index.cshtml
+++ b/MvcAdminTemplate/Views/Forms/Index.cshtml
@@ -316,4 +316,4 @@
         });
     </script>
 }
-}
+//} excess curly brace here 


### PR DESCRIPTION
Hi ,see this page output when i browse the forms and scroll down at the end of page i see this extra curly brace :)
![image](https://user-images.githubusercontent.com/13925864/38671147-30afd5c2-3e7d-11e8-9291-27c841aa600b.png)
there's a excess curly brace here  at   _MvcAdminTemplate/Views/Forms/Index.cshtml_ **`line 319`**
